### PR TITLE
Fix prediction handler bug

### DIFF
--- a/Experiments/c4dot5/DecisionTree.py
+++ b/Experiments/c4dot5/DecisionTree.py
@@ -81,5 +81,5 @@ class DecisionTree:
             raise PredictionHandlerNotFound("Fit the decision tree before predicting.")
         return self.prediction_handler.predict(data_input, self.get_root_node())
 
-    def set_prediction_handler(self, prediciton_handler: PredictionHandler):
-        self.prediction_handler = prediciton_handler
+    def set_prediction_handler(self, prediction_handler: PredictionHandler):
+        self.prediction_handler = prediction_handler

--- a/Experiments/c4dot5/predictor.py
+++ b/Experiments/c4dot5/predictor.py
@@ -18,13 +18,15 @@ class PredictionHandler:
 
     def _predict(self, row_input: pd.Series, node: Node):
         if node is None:
-            breakpoint()
+            raise ValueError("Prediction reached a null node")
         attribute = node.get_attribute().split(":")[0]
         # in case of unknown variable more the data are passed to all children
         childs = select_children_for_prediction(row_input[attribute], node)
         for child in childs:
             if child is None:
-                breakpoint()
+                raise ValueError(
+                    "Prediction encountered an unexpected null child node"
+                )
             if isinstance(child, LeafNode):
                 self._predictions_dict[child.get_label()] = child.get_classes()
             else:


### PR DESCRIPTION
## Summary
- replace debug breakpoints in the predictor with exceptions
- correct typo in `DecisionTree`'s `set_prediction_handler`

## Testing
- `python -m py_compile Experiments/c4dot5/*.py`
- `python -m py_compile $(git ls-files '*.py')`
