### PR TITLE
Fix docstring typo

### DIFF
--- a/Experiments/c4dot5/decision_tree_utils.py
+++ b/Experiments/c4dot5/decision_tree_utils.py
@@ -13,7 +13,7 @@ def extract_rules_from_leaf(node):
 def get_total_threshold(data, local_threshold) -> float:
     """ Computes the threshold on the total dataset
 
-    The global threshold is the maximum number less then or equal to the local one
+    The global threshold is the maximum number less than or equal to the local one
     """
     data = data[data != '?'].astype(float)
     return data[data.le(local_threshold)].max()


### PR DESCRIPTION
## Summary
- fix minor typo in `decision_tree_utils.get_total_threshold`

## Testing
- `./pytest`